### PR TITLE
Add TypeScript debug visualizer package

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Python CI
+name: CI
 
 on: [push]
 
@@ -21,3 +21,18 @@ jobs:
         PYTHONPATH: ${{ github.workspace }}
       run: |
         pytest tests/
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '24'
+        cache: npm
+        cache-dependency-path: typescript/package-lock.json
+    - name: Install TypeScript dependencies
+      working-directory: typescript
+      run: npm ci
+    - name: Run TypeScript tests
+      working-directory: typescript
+      run: npm test
+    - name: Build TypeScript package
+      working-directory: typescript
+      run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 *.pyc
 *.html
+.venv/
 __pycache__/
+typescript/coverage/
+typescript/dist/
+typescript/node_modules/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,69 @@
+# debugvisualizer
+
+Geometry helpers for the VS Code
+[Debug Visualizer](https://github.com/hediet/vscode-debug-visualizer)
+extension.
+
+This repository keeps language implementations isolated so Python and
+TypeScript can evolve without sharing package metadata or build output.
+
+## Packages
+
+| Package | Location | Runtime | Status |
+| --- | --- | --- | --- |
+| Python | repository root | Shapely, Trimesh, Plotly | Existing implementation |
+| TypeScript | `typescript/` | No runtime dependencies | Generic geometry-to-Plotly Debug Visualizer helpers |
+
+## Python
+
+```python
+from debugvisualizer import Plotter
+
+view = Plotter(site_extruded, mass_extruded, possible_boundaries)
+view.visualize()
+```
+
+The Python implementation accepts Shapely and Trimesh geometry objects and
+returns Plotly JSON that Debug Visualizer can render.
+
+## TypeScript
+
+```ts
+import { Plotter, lineString, mesh, polygon } from "debugvisualizer";
+
+const view = new Plotter([
+  polygon(siteBoundary, "site"),
+  mesh(vertices, faces, "mass"),
+  lineString(sectionLine, "section")
+]);
+
+debugger;
+```
+
+At the breakpoint, open `Debug Visualizer: New View` and use `view` as the
+expression. The TypeScript `Plotter` implements `getVisualizationData()`, so the
+Debug Visualizer JavaScript/TypeScript extractor can render it directly.
+
+The TypeScript package is intentionally generic. It understands GeoJSON-like
+point, line, polygon, multi-geometry, feature, and feature collection objects,
+plus mesh-like `{ vertices, faces }` or `{ positions, indices }` objects. Project
+or application classes should be converted with the `adapters` option instead of
+being baked into this package.
+
+## Development
+
+Python checks:
+
+```bash
+pip install -r requirements.txt
+PYTHONPATH=. pytest tests/
+```
+
+TypeScript checks:
+
+```bash
+cd typescript
+npm ci
+npm test
+npm run build
+```

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -1,0 +1,117 @@
+# debugvisualizer TypeScript
+
+TypeScript helpers for visualizing geometry with the VS Code
+[Debug Visualizer](https://github.com/hediet/vscode-debug-visualizer)
+extension.
+
+The package emits Debug Visualizer-compatible Plotly data:
+
+```ts
+{
+  kind: { plotly: true },
+  data: [
+    // scatter3d and mesh3d traces
+  ],
+  layout: {
+    scene: { aspectmode: "data" }
+  }
+}
+```
+
+## Usage
+
+```ts
+import { Plotter, lineString, mesh, polygon } from "debugvisualizer";
+
+const view = new Plotter(
+  [
+    polygon(
+      [
+        [0, 0, 0],
+        [2, 0, 0],
+        [2, 2, 0],
+        [0, 2, 0],
+        [0, 0, 0]
+      ],
+      "parcel"
+    ),
+    lineString(
+      [
+        [0, 0, 1],
+        [1, 1, 2]
+      ],
+      "edge"
+    ),
+    mesh(
+      [
+        [0, 0, 0],
+        [1, 0, 0],
+        [1, 1, 0],
+        [0, 1, 0]
+      ],
+      [
+        [0, 1, 2],
+        [0, 2, 3]
+      ],
+      "slab"
+    )
+  ],
+  { orthographic: true, showVertices: false }
+);
+
+debugger;
+```
+
+When execution stops at the breakpoint, open `Debug Visualizer: New View` and
+enter `view` as the expression. The extension calls `getVisualizationData()` and
+renders the returned Plotly traces.
+
+Use `view.getVisualizationData()` when you want the raw object, or
+`view.visualize(true)` when you need a JSON string.
+
+## Geometry Inputs
+
+- `point([x, y, z?], name?)`
+- GeoJSON-like `Point` / `MultiPoint`
+- `lineString([[x, y, z?], ...], name?)`
+- GeoJSON-like `LineString` / `MultiLineString`
+- `polygon(ringOrRings, name?)`
+- GeoJSON-like `Polygon` / `MultiPolygon`
+- GeoJSON-like `Feature` / `FeatureCollection`
+- `mesh(vertices, faces, name?)`
+- mesh-like `{ vertices, faces }`
+- mesh-like `{ positions, indices }`
+
+`mapZToY` swaps `y` and `z` in emitted traces for projects that use z-up model
+coordinates but want y-up visualization.
+
+## Custom Adapters
+
+Keep application-specific types out of the package core. Use `adapters` to map
+project objects into generic geometry:
+
+```ts
+const view = new Plotter([domainSegment], {
+  adapters: [
+    (value) => {
+      if (!(value instanceof DomainSegment)) {
+        return undefined;
+      }
+
+      return lineString([value.start, value.end], value.label);
+    }
+  ]
+});
+```
+
+Adapters are tried only when a value is not already recognized as built-in
+geometry. Returning `undefined` means "this adapter does not handle the value".
+
+## Development
+
+```bash
+npm ci
+npm test
+npm run typecheck
+npm run build
+```

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,0 +1,1307 @@
+{
+  "name": "debugvisualizer",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "debugvisualizer",
+      "version": "0.1.0",
+      "license": "UNLICENSED",
+      "devDependencies": {
+        "typescript": "^5.6.3",
+        "vitest": "^4.1.6"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
+      "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
+      "integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
+      "integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
+      "integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
+      "integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
+      "integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
+      "integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
+      "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
+      "integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
+      "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
+      "integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
+      "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
+      "integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
+      "integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
+      "integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
+      "integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
+      "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.130.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.1",
+        "@rolldown/binding-darwin-arm64": "1.0.1",
+        "@rolldown/binding-darwin-x64": "1.0.1",
+        "@rolldown/binding-freebsd-x64": "1.0.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.1",
+        "@rolldown/binding-linux-arm64-musl": "1.0.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-musl": "1.0.1",
+        "@rolldown/binding-openharmony-arm64": "1.0.1",
+        "@rolldown/binding-wasm32-wasi": "1.0.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.1",
+        "@rolldown/binding-win32-x64-msvc": "1.0.1"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.13",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
+      "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.1",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "UNLICENSED",
       "devDependencies": {
+        "@types/node": "^24.12.4",
         "typescript": "^5.6.3",
         "vitest": "^4.1.6"
       }
@@ -176,9 +177,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -196,9 +194,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -216,9 +211,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -236,9 +228,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -256,9 +245,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -276,9 +262,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -407,6 +390,16 @@
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.6",
@@ -761,9 +754,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -785,9 +775,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -809,9 +796,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -833,9 +817,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1117,6 +1098,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "8.0.13",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "debugvisualizer",
+  "version": "0.1.0",
+  "description": "TypeScript helpers for visualizing geometry with VS Code Debug Visualizer.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "keywords": [
+    "debug",
+    "debug-visualizer",
+    "geometry",
+    "plotly",
+    "typescript"
+  ],
+  "license": "UNLICENSED",
+  "devDependencies": {
+    "typescript": "^5.6.3",
+    "vitest": "^4.1.6"
+  }
+}

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -16,8 +16,9 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "prepack": "npm run build",
     "test": "vitest run",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json"
   },
   "keywords": [
     "debug",
@@ -28,6 +29,7 @@
   ],
   "license": "UNLICENSED",
   "devDependencies": {
+    "@types/node": "^24.12.4",
     "typescript": "^5.6.3",
     "vitest": "^4.1.6"
   }

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -581,11 +581,11 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function isArrayLikeNumber(value: unknown): value is ArrayLike<number> {
-  if (!isRecord(value) || typeof value.length !== "number" || value.length === 0) {
+  if (!isRecord(value) || typeof value.length !== "number") {
     return false;
   }
 
-  return typeof value[0] === "number";
+  return value.length === 0 || typeof value[0] === "number";
 }
 
 function isCoordinate(value: unknown): value is Coordinate {

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -116,6 +116,7 @@ export type GeometryInput =
   | MultiLineStringGeometry
   | MultiPolygonGeometry
   | MeshGeometry
+  | MeshLikeGeometry
   | FeatureGeometry
   | FeatureCollectionGeometry
   | GeometryInput[];
@@ -138,31 +139,31 @@ export const point = (coordinates: Coordinate, name?: string): PointGeometry => 
 });
 
 export const lineString = (
-  coordinates: Coordinate[],
+  coordinates: readonly Coordinate[],
   name?: string
 ): LineStringGeometry => ({
   type: "LineString",
-  coordinates,
+  coordinates: coordinates as Coordinate[],
   ...(name === undefined ? {} : { name })
 });
 
 export const polygon = (
-  coordinates: Coordinate[] | Coordinate[][],
+  coordinates: readonly Coordinate[] | readonly (readonly Coordinate[])[],
   name?: string
 ): PolygonGeometry => ({
   type: "Polygon",
-  coordinates,
+  coordinates: coordinates as Coordinate[] | Coordinate[][],
   ...(name === undefined ? {} : { name })
 });
 
 export const mesh = (
-  vertices: Coordinate[],
-  faces: MeshFace[],
+  vertices: readonly Coordinate[],
+  faces: readonly MeshFace[],
   name?: string
 ): MeshGeometry => ({
   type: "Mesh",
-  vertices,
-  faces,
+  vertices: vertices as Coordinate[],
+  faces: faces as MeshFace[],
   ...(name === undefined ? {} : { name })
 });
 
@@ -445,16 +446,22 @@ function normalizeMeshLikeGeometry(value: MeshLikeGeometry): MeshGeometry {
 function hasCoordinateInput(
   value: unknown
 ): value is Coordinate[] | ArrayLike<number> {
-  if (Array.isArray(value) && value.length > 0) {
-    return isCoordinate(value[0]) || typeof value[0] === "number";
+  if (Array.isArray(value)) {
+    return (
+      value.length === 0 ||
+      isCoordinate(value[0]) ||
+      typeof value[0] === "number"
+    );
   }
 
   return isArrayLikeNumber(value);
 }
 
 function hasFaceInput(value: unknown): value is MeshFace[] | ArrayLike<number> {
-  if (Array.isArray(value) && value.length > 0) {
-    return isFace(value[0]) || typeof value[0] === "number";
+  if (Array.isArray(value)) {
+    return (
+      value.length === 0 || isFace(value[0]) || typeof value[0] === "number"
+    );
   }
 
   return isArrayLikeNumber(value);
@@ -519,19 +526,23 @@ function isFace(value: unknown): value is MeshFace {
 }
 
 function isScatterGeometry(value: unknown): value is ScatterGeometry {
+  if (!isRecord(value) || typeof value.type !== "string") {
+    return false;
+  }
+  if (!("coordinates" in value)) {
+    return false;
+  }
+  if (value.type === "Point") {
+    return isCoordinate(value.coordinates);
+  }
   return (
-    isRecord(value) &&
-    typeof value.type === "string" &&
     [
-      "Point",
       "MultiPoint",
       "LineString",
       "Polygon",
       "MultiLineString",
       "MultiPolygon"
-    ].includes(value.type) &&
-    "coordinates" in value &&
-    Array.isArray(value.coordinates)
+    ].includes(value.type) && Array.isArray(value.coordinates)
   );
 }
 

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -135,7 +135,7 @@ export interface PlotterOptions {
   mapZToY?: boolean;
   orthographic?: boolean;
   showVertices?: boolean;
-  adapters?: GeometryAdapter[];
+  adapters?: readonly GeometryAdapter[];
 }
 
 export type GeometryAdapter = (
@@ -179,7 +179,7 @@ export const mesh = (
 
 export class Plotter {
   constructor(
-    private readonly geometries: unknown[] = [],
+    private readonly geometries: readonly unknown[] = [],
     private readonly options: PlotterOptions = {}
   ) {}
 

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -1,0 +1,603 @@
+export interface PlotlyVisualizationData {
+  kind: { plotly: true };
+  data: PlotlyTrace[];
+  layout: PlotlyLayout;
+}
+
+export interface PlotlyLayout {
+  scene: {
+    xaxis_title: string;
+    yaxis_title: string;
+    zaxis_title: string;
+    aspectmode: "data";
+    camera?: {
+      projection: {
+        type: "orthographic";
+      };
+    };
+  };
+}
+
+export interface PlotlyTrace {
+  type?: string;
+  mode?: string;
+  name?: string;
+  showlegend?: boolean;
+  opacity?: number;
+  x?: Array<number | null>;
+  y?: Array<number | null>;
+  z?: Array<number | null>;
+  i?: number[];
+  j?: number[];
+  k?: number[];
+}
+
+export type Coordinate =
+  | readonly [number, number]
+  | readonly [number, number, number]
+  | { readonly x: number; readonly y: number; readonly z?: number };
+
+export type MeshFace = readonly [number, number, number];
+
+export interface PointGeometry {
+  type: "Point";
+  coordinates: Coordinate;
+  name?: string;
+}
+
+export interface MultiPointGeometry {
+  type: "MultiPoint";
+  coordinates: Coordinate[];
+  name?: string;
+}
+
+export interface LineStringGeometry {
+  type: "LineString";
+  coordinates: Coordinate[];
+  name?: string;
+}
+
+export interface PolygonGeometry {
+  type: "Polygon";
+  coordinates: Coordinate[] | Coordinate[][];
+  name?: string;
+}
+
+export interface MultiLineStringGeometry {
+  type: "MultiLineString";
+  coordinates: Coordinate[][];
+  name?: string;
+}
+
+export interface MultiPolygonGeometry {
+  type: "MultiPolygon";
+  coordinates: Array<Coordinate[] | Coordinate[][]>;
+  name?: string;
+}
+
+export interface MeshGeometry {
+  type: "Mesh";
+  vertices: Coordinate[];
+  faces: MeshFace[];
+  name?: string;
+}
+
+export interface MeshLikeGeometry {
+  type?: string;
+  vertices?: Coordinate[] | ArrayLike<number>;
+  positions?: Coordinate[] | ArrayLike<number>;
+  faces?: MeshFace[] | ArrayLike<number>;
+  indices?: MeshFace[] | ArrayLike<number>;
+  name?: string;
+}
+
+export interface FeatureGeometry {
+  type: "Feature";
+  geometry: GeometryInput | null;
+  properties?: {
+    name?: string;
+    [key: string]: unknown;
+  } | null;
+  id?: string | number;
+  name?: string;
+}
+
+export interface FeatureCollectionGeometry {
+  type: "FeatureCollection";
+  features: FeatureGeometry[];
+  name?: string;
+}
+
+export type GeometryInput =
+  | PointGeometry
+  | MultiPointGeometry
+  | LineStringGeometry
+  | PolygonGeometry
+  | MultiLineStringGeometry
+  | MultiPolygonGeometry
+  | MeshGeometry
+  | FeatureGeometry
+  | FeatureCollectionGeometry
+  | GeometryInput[];
+
+export interface PlotterOptions {
+  mapZToY?: boolean;
+  orthographic?: boolean;
+  showVertices?: boolean;
+  adapters?: GeometryAdapter[];
+}
+
+export type GeometryAdapter = (
+  value: unknown
+) => GeometryInput | GeometryInput[] | undefined;
+
+export const point = (coordinates: Coordinate, name?: string): PointGeometry => ({
+  type: "Point",
+  coordinates,
+  ...(name === undefined ? {} : { name })
+});
+
+export const lineString = (
+  coordinates: Coordinate[],
+  name?: string
+): LineStringGeometry => ({
+  type: "LineString",
+  coordinates,
+  ...(name === undefined ? {} : { name })
+});
+
+export const polygon = (
+  coordinates: Coordinate[] | Coordinate[][],
+  name?: string
+): PolygonGeometry => ({
+  type: "Polygon",
+  coordinates,
+  ...(name === undefined ? {} : { name })
+});
+
+export const mesh = (
+  vertices: Coordinate[],
+  faces: MeshFace[],
+  name?: string
+): MeshGeometry => ({
+  type: "Mesh",
+  vertices,
+  faces,
+  ...(name === undefined ? {} : { name })
+});
+
+export class Plotter {
+  constructor(
+    private readonly geometries: unknown[] = [],
+    private readonly options: PlotterOptions = {}
+  ) {}
+
+  getVisualizationData(): PlotlyVisualizationData {
+    const layout: PlotlyLayout = {
+      scene: {
+        xaxis_title: "X Axis",
+        yaxis_title: "Y Axis",
+        zaxis_title: "Z Axis",
+        aspectmode: "data"
+      }
+    };
+
+    if (this.options.orthographic ?? true) {
+      layout.scene.camera = {
+        projection: {
+          type: "orthographic"
+        }
+      };
+    }
+
+    return {
+      kind: { plotly: true },
+      data: this.geometries.flatMap((geometry) => this.toTraces(geometry)),
+      layout
+    };
+  }
+
+  visualize(toJson = false): PlotlyVisualizationData | string {
+    const data = this.getVisualizationData();
+    return toJson ? JSON.stringify(data) : data;
+  }
+
+  private toTraces(geometry: unknown): PlotlyTrace[] {
+    if (Array.isArray(geometry)) {
+      return geometry.flatMap((child) => this.toTraces(child));
+    }
+
+    if (isMeshLikeGeometry(geometry)) {
+      return [this.meshTrace(normalizeMeshLikeGeometry(geometry))];
+    }
+
+    if (isFeatureCollectionGeometry(geometry)) {
+      return geometry.features.flatMap((feature) => this.toTraces(feature));
+    }
+
+    if (isFeatureGeometry(geometry)) {
+      if (geometry.geometry === null) {
+        return [];
+      }
+
+      return this.toTraces(withFeatureName(geometry.geometry, geometry));
+    }
+
+    if (isMeshGeometry(geometry)) {
+      return [this.meshTrace(geometry)];
+    }
+
+    if (isScatterGeometry(geometry)) {
+      return [this.scatterTrace(geometry)];
+    }
+
+    for (const adapter of this.options.adapters ?? []) {
+      const adapted = adapter(geometry);
+      if (adapted !== undefined) {
+        return this.toTraces(adapted);
+      }
+    }
+
+    throw new Error("Unsupported geometry input.");
+  }
+
+  private meshTrace(geometry: MeshGeometry): PlotlyTrace {
+    const vertices = geometry.vertices.map((coordinate) =>
+      this.coordinateToXyz(coordinate)
+    );
+
+    return {
+      type: "mesh3d",
+      name: geometry.name ?? "mesh",
+      showlegend: true,
+      opacity: 0.6,
+      x: vertices.map((vertex) => vertex.x),
+      y: vertices.map((vertex) => vertex.y),
+      z: vertices.map((vertex) => vertex.z),
+      i: geometry.faces.map((face) => face[0]),
+      j: geometry.faces.map((face) => face[1]),
+      k: geometry.faces.map((face) => face[2])
+    };
+  }
+
+  private scatterTrace(
+    geometry: ScatterGeometry
+  ): PlotlyTrace {
+    const x: Array<number | null> = [];
+    const y: Array<number | null> = [];
+    const z: Array<number | null> = [];
+
+    if (geometry.type === "Point") {
+      this.pushCoordinate({ x, y, z }, geometry.coordinates);
+    } else if (geometry.type === "MultiPoint") {
+      for (const coordinate of geometry.coordinates) {
+        this.pushCoordinate({ x, y, z }, coordinate);
+      }
+    } else {
+      for (const ring of this.getLineRings(geometry)) {
+        this.pushRing({ x, y, z }, ring);
+      }
+    }
+
+    return {
+      type: "scatter3d",
+      mode: isPointType(geometry.type) ? "markers" : this.lineMode(),
+      name: geometry.name ?? "geometry",
+      showlegend: true,
+      opacity: 0.6,
+      x,
+      y,
+      z
+    };
+  }
+
+  private getLineRings(
+    geometry:
+      | LineStringGeometry
+      | PolygonGeometry
+      | MultiLineStringGeometry
+      | MultiPolygonGeometry
+  ): Coordinate[][] {
+    if (geometry.type === "LineString") {
+      return [geometry.coordinates];
+    }
+
+    if (geometry.type === "MultiLineString") {
+      return geometry.coordinates;
+    }
+
+    if (geometry.type === "Polygon") {
+      return normalizePolygonCoordinates(geometry.coordinates);
+    }
+
+    return geometry.coordinates.flatMap((polygonCoordinates) =>
+      normalizePolygonCoordinates(polygonCoordinates)
+    );
+  }
+
+  private lineMode(): string {
+    return this.options.showVertices === false ? "lines" : "lines+markers";
+  }
+
+  private pushRing(
+    values: {
+      x: Array<number | null>;
+      y: Array<number | null>;
+      z: Array<number | null>;
+    },
+    ring: Coordinate[]
+  ): void {
+    for (const coordinate of ring) {
+      this.pushCoordinate(values, coordinate);
+    }
+    values.x.push(null);
+    values.y.push(null);
+    values.z.push(null);
+  }
+
+  private pushCoordinate(
+    values: {
+      x: Array<number | null>;
+      y: Array<number | null>;
+      z: Array<number | null>;
+    },
+    coordinate: Coordinate
+  ): void {
+    const mapped = this.coordinateToXyz(coordinate);
+    values.x.push(mapped.x);
+    values.y.push(mapped.y);
+    values.z.push(mapped.z);
+  }
+
+  private coordinateToXyz(coordinate: Coordinate): {
+    x: number;
+    y: number;
+    z: number;
+  } {
+    let x: number;
+    let y: number;
+    let z: number;
+
+    if (isTupleCoordinate(coordinate)) {
+      x = coordinate[0];
+      y = coordinate[1];
+      z = coordinate[2] ?? 0;
+    } else {
+      x = coordinate.x;
+      y = coordinate.y;
+      z = coordinate.z ?? 0;
+    }
+
+    if (this.options.mapZToY) {
+      return { x, y: z, z: y };
+    }
+
+    return { x, y, z };
+  }
+}
+
+type ScatterGeometry =
+  | PointGeometry
+  | MultiPointGeometry
+  | LineStringGeometry
+  | PolygonGeometry
+  | MultiLineStringGeometry
+  | MultiPolygonGeometry;
+
+function isPointType(type: string): boolean {
+  return type === "Point" || type === "MultiPoint";
+}
+
+function isFeatureCollectionGeometry(
+  value: unknown
+): value is FeatureCollectionGeometry {
+  return (
+    isRecord(value) &&
+    value.type === "FeatureCollection" &&
+    Array.isArray(value.features)
+  );
+}
+
+function isFeatureGeometry(value: unknown): value is FeatureGeometry {
+  return (
+    isRecord(value) &&
+    value.type === "Feature" &&
+    "geometry" in value &&
+    (value.geometry === null || isRecord(value.geometry))
+  );
+}
+
+function isMeshGeometry(value: unknown): value is MeshGeometry {
+  return (
+    isRecord(value) &&
+    value.type === "Mesh" &&
+    Array.isArray(value.vertices) &&
+    Array.isArray(value.faces)
+  );
+}
+
+function isMeshLikeGeometry(value: unknown): value is MeshLikeGeometry {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const vertices = value.vertices ?? value.positions;
+  const faces = value.faces ?? value.indices;
+  return hasCoordinateInput(vertices) && hasFaceInput(faces);
+}
+
+function normalizeMeshLikeGeometry(value: MeshLikeGeometry): MeshGeometry {
+  const vertexInput = value.vertices ?? value.positions;
+  const faceInput = value.faces ?? value.indices;
+
+  if (!hasCoordinateInput(vertexInput) || !hasFaceInput(faceInput)) {
+    throw new Error("Invalid mesh-like geometry input.");
+  }
+
+  return {
+    type: "Mesh",
+    vertices: normalizeCoordinateList(vertexInput),
+    faces: normalizeFaceList(faceInput),
+    ...(value.name === undefined ? {} : { name: value.name })
+  };
+}
+
+function hasCoordinateInput(
+  value: unknown
+): value is Coordinate[] | ArrayLike<number> {
+  if (Array.isArray(value) && value.length > 0) {
+    return isCoordinate(value[0]) || typeof value[0] === "number";
+  }
+
+  return isArrayLikeNumber(value);
+}
+
+function hasFaceInput(value: unknown): value is MeshFace[] | ArrayLike<number> {
+  if (Array.isArray(value) && value.length > 0) {
+    return isFace(value[0]) || typeof value[0] === "number";
+  }
+
+  return isArrayLikeNumber(value);
+}
+
+function normalizeCoordinateList(
+  value: Coordinate[] | ArrayLike<number>
+): Coordinate[] {
+  if (Array.isArray(value) && value.length > 0 && isCoordinate(value[0])) {
+    return value as Coordinate[];
+  }
+
+  return chunkNumbers(value as ArrayLike<number>, 3).map(
+    ([x, y, z]) => [x, y, z] as const
+  );
+}
+
+function normalizeFaceList(value: MeshFace[] | ArrayLike<number>): MeshFace[] {
+  if (Array.isArray(value) && value.length > 0 && isFace(value[0])) {
+    return value as MeshFace[];
+  }
+
+  return chunkNumbers(value as ArrayLike<number>, 3).map(
+    ([i, j, k]) => [i, j, k] as const
+  );
+}
+
+function chunkNumbers(
+  value: ArrayLike<number>,
+  chunkSize: 3
+): Array<[number, number, number]> {
+  if (value.length % chunkSize !== 0) {
+    throw new Error("Flat mesh arrays must be divisible into triples.");
+  }
+
+  const chunks: Array<[number, number, number]> = [];
+  for (let index = 0; index < value.length; index += chunkSize) {
+    const first = value[index];
+    const second = value[index + 1];
+    const third = value[index + 2];
+    if (
+      typeof first !== "number" ||
+      typeof second !== "number" ||
+      typeof third !== "number"
+    ) {
+      throw new Error("Flat mesh arrays must contain numbers.");
+    }
+
+    chunks.push([first, second, third]);
+  }
+
+  return chunks;
+}
+
+function isFace(value: unknown): value is MeshFace {
+  return (
+    Array.isArray(value) &&
+    typeof value[0] === "number" &&
+    typeof value[1] === "number" &&
+    typeof value[2] === "number"
+  );
+}
+
+function isScatterGeometry(value: unknown): value is ScatterGeometry {
+  return (
+    isRecord(value) &&
+    typeof value.type === "string" &&
+    [
+      "Point",
+      "MultiPoint",
+      "LineString",
+      "Polygon",
+      "MultiLineString",
+      "MultiPolygon"
+    ].includes(value.type) &&
+    "coordinates" in value &&
+    Array.isArray(value.coordinates)
+  );
+}
+
+function withFeatureName(
+  geometry: GeometryInput,
+  feature: FeatureGeometry
+): GeometryInput {
+  if (Array.isArray(geometry)) {
+    return geometry;
+  }
+
+  const featureName =
+    feature.name ?? feature.properties?.name ?? feature.id?.toString();
+  if (featureName === undefined || geometry.name !== undefined) {
+    return geometry;
+  }
+
+  return { ...geometry, name: featureName };
+}
+
+function normalizePolygonCoordinates(
+  coordinates: Coordinate[] | Coordinate[][]
+): Coordinate[][] {
+  if (coordinates.length === 0) {
+    return [];
+  }
+
+  const first = coordinates[0];
+  return first !== undefined && isCoordinate(first)
+    ? [coordinates as Coordinate[]]
+    : coordinates as Coordinate[][];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isArrayLikeNumber(value: unknown): value is ArrayLike<number> {
+  if (!isRecord(value) || typeof value.length !== "number" || value.length === 0) {
+    return false;
+  }
+
+  return typeof value[0] === "number";
+}
+
+function isCoordinate(value: unknown): value is Coordinate {
+  if (isTupleCoordinate(value)) {
+    return true;
+  }
+
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "x" in value &&
+    "y" in value &&
+    typeof value.x === "number" &&
+    typeof value.y === "number"
+  );
+}
+
+function isTupleCoordinate(
+  value: unknown
+): value is readonly [number, number, number?] {
+  return (
+    Array.isArray(value) &&
+    typeof value[0] === "number" &&
+    typeof value[1] === "number"
+  );
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -47,38 +47,40 @@ export interface PointGeometry {
 
 export interface MultiPointGeometry {
   type: "MultiPoint";
-  coordinates: Coordinate[];
+  coordinates: readonly Coordinate[];
   name?: string;
 }
 
 export interface LineStringGeometry {
   type: "LineString";
-  coordinates: Coordinate[];
+  coordinates: readonly Coordinate[];
   name?: string;
 }
 
 export interface PolygonGeometry {
   type: "Polygon";
-  coordinates: Coordinate[] | Coordinate[][];
+  coordinates: readonly Coordinate[] | readonly (readonly Coordinate[])[];
   name?: string;
 }
 
 export interface MultiLineStringGeometry {
   type: "MultiLineString";
-  coordinates: Coordinate[][];
+  coordinates: readonly (readonly Coordinate[])[];
   name?: string;
 }
 
 export interface MultiPolygonGeometry {
   type: "MultiPolygon";
-  coordinates: Array<Coordinate[] | Coordinate[][]>;
+  coordinates: ReadonlyArray<
+    readonly Coordinate[] | readonly (readonly Coordinate[])[]
+  >;
   name?: string;
 }
 
 export interface MeshGeometry {
   type: "Mesh";
-  vertices: Coordinate[];
-  faces: MeshFace[];
+  vertices: readonly Coordinate[];
+  faces: readonly MeshFace[];
   name?: string;
 }
 
@@ -151,7 +153,7 @@ export const lineString = (
   name?: string
 ): LineStringGeometry => ({
   type: "LineString",
-  coordinates: coordinates as Coordinate[],
+  coordinates,
   ...(name === undefined ? {} : { name })
 });
 
@@ -160,7 +162,7 @@ export const polygon = (
   name?: string
 ): PolygonGeometry => ({
   type: "Polygon",
-  coordinates: coordinates as Coordinate[] | Coordinate[][],
+  coordinates,
   ...(name === undefined ? {} : { name })
 });
 
@@ -170,8 +172,8 @@ export const mesh = (
   name?: string
 ): MeshGeometry => ({
   type: "Mesh",
-  vertices: vertices as Coordinate[],
-  faces: faces as MeshFace[],
+  vertices,
+  faces,
   ...(name === undefined ? {} : { name })
 });
 
@@ -306,7 +308,7 @@ export class Plotter {
       | PolygonGeometry
       | MultiLineStringGeometry
       | MultiPolygonGeometry
-  ): Coordinate[][] {
+  ): ReadonlyArray<readonly Coordinate[]> {
     if (geometry.type === "LineString") {
       return [geometry.coordinates];
     }
@@ -334,7 +336,7 @@ export class Plotter {
       y: Array<number | null>;
       z: Array<number | null>;
     },
-    ring: Coordinate[]
+    ring: readonly Coordinate[]
   ): void {
     for (const coordinate of ring) {
       this.pushCoordinate(values, coordinate);
@@ -572,16 +574,16 @@ function withFeatureName(
 }
 
 function normalizePolygonCoordinates(
-  coordinates: Coordinate[] | Coordinate[][]
-): Coordinate[][] {
+  coordinates: readonly Coordinate[] | readonly (readonly Coordinate[])[]
+): ReadonlyArray<readonly Coordinate[]> {
   if (coordinates.length === 0) {
     return [];
   }
 
   const first = coordinates[0];
   return first !== undefined && isCoordinate(first)
-    ? [coordinates as Coordinate[]]
-    : coordinates as Coordinate[][];
+    ? [coordinates as readonly Coordinate[]]
+    : (coordinates as ReadonlyArray<readonly Coordinate[]>);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -82,14 +82,22 @@ export interface MeshGeometry {
   name?: string;
 }
 
-export interface MeshLikeGeometry {
+type MeshCoordinateInput = Coordinate[] | ArrayLike<number>;
+type MeshFaceInput = MeshFace[] | ArrayLike<number>;
+
+type MeshLikeVertices =
+  | { vertices: MeshCoordinateInput; positions?: MeshCoordinateInput }
+  | { vertices?: MeshCoordinateInput; positions: MeshCoordinateInput };
+
+type MeshLikeFaces =
+  | { faces: MeshFaceInput; indices?: MeshFaceInput }
+  | { faces?: MeshFaceInput; indices: MeshFaceInput };
+
+export type MeshLikeGeometry = {
   type?: string;
-  vertices?: Coordinate[] | ArrayLike<number>;
-  positions?: Coordinate[] | ArrayLike<number>;
-  faces?: MeshFace[] | ArrayLike<number>;
-  indices?: MeshFace[] | ArrayLike<number>;
   name?: string;
-}
+} & MeshLikeVertices &
+  MeshLikeFaces;
 
 export interface FeatureGeometry {
   type: "Feature";

--- a/typescript/tests/debugger-evaluation.test.ts
+++ b/typescript/tests/debugger-evaluation.test.ts
@@ -1,0 +1,92 @@
+import inspector from "node:inspector";
+import { afterEach, describe, expect, it } from "vitest";
+import { lineString, Plotter } from "../src/index";
+
+const session = new inspector.Session();
+
+function post<T>(method: string, params: Record<string, unknown> = {}) {
+  return new Promise<T>((resolve, reject) => {
+    session.post(method, params, (error, result) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve(result as T);
+    });
+  });
+}
+
+describe("debugger evaluation", () => {
+  afterEach(() => {
+    try {
+      session.disconnect();
+    } catch {
+      // The session might already be disconnected after a failed setup.
+    }
+  });
+
+  it("evaluates Plotter visualization data from the current breakpoint frame", async () => {
+    session.connect();
+    await post("Debugger.enable");
+
+    const paused = new Promise<Record<string, unknown>>((resolve, reject) => {
+      session.once("Debugger.paused", (message) => {
+        const callFrameId = message.params.callFrames[0]?.callFrameId;
+        if (!callFrameId) {
+          reject(new Error("Debugger paused without a call frame."));
+          return;
+        }
+
+        post<{
+          result: {
+            value: Record<string, unknown>;
+          };
+        }>("Debugger.evaluateOnCallFrame", {
+          callFrameId,
+          expression: "view.getVisualizationData()",
+          returnByValue: true
+        })
+          .then((response) => resolve(response.result.value))
+          .catch(reject);
+      });
+    });
+
+    function stopAtBreakpoint() {
+      const view = new Plotter([
+        lineString(
+          [
+            [0, 0, 0],
+            [2, 0, 1]
+          ],
+          "debug-line"
+        )
+      ]);
+
+      debugger;
+    }
+
+    stopAtBreakpoint();
+    const visualization = await paused;
+
+    expect(visualization).toMatchObject({
+      kind: { plotly: true },
+      data: [
+        {
+          type: "scatter3d",
+          mode: "lines+markers",
+          name: "debug-line",
+          x: [0, 2, null],
+          y: [0, 0, null],
+          z: [0, 1, null]
+        }
+      ],
+      layout: {
+        scene: {
+          aspectmode: "data",
+          camera: { projection: { type: "orthographic" } }
+        }
+      }
+    });
+  });
+});

--- a/typescript/tests/package.test.ts
+++ b/typescript/tests/package.test.ts
@@ -17,7 +17,7 @@ describe("TypeScript package metadata", () => {
     expect(packageJson.scripts).toMatchObject({
       build: "tsc -p tsconfig.json",
       test: "vitest run",
-      typecheck: "tsc -p tsconfig.json --noEmit"
+      typecheck: "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json"
     });
   });
 });

--- a/typescript/tests/package.test.ts
+++ b/typescript/tests/package.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const packageJson = JSON.parse(
+  readFileSync(join(process.cwd(), "package.json"), "utf8")
+) as {
+  name?: string;
+  scripts?: Record<string, string>;
+  exports?: Record<string, unknown>;
+};
+
+describe("TypeScript package metadata", () => {
+  it("publishes a single isolated ESM entrypoint with build and test scripts", () => {
+    expect(packageJson.name).toBe("debugvisualizer");
+    expect(packageJson.exports).toHaveProperty(".");
+    expect(packageJson.scripts).toMatchObject({
+      build: "tsc -p tsconfig.json",
+      test: "vitest run",
+      typecheck: "tsc -p tsconfig.json --noEmit"
+    });
+  });
+});

--- a/typescript/tests/plotter.test.ts
+++ b/typescript/tests/plotter.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+import { lineString, mesh, point, polygon, Plotter } from "../src/index";
+
+describe("Plotter", () => {
+  it("emits Debug Visualizer Plotly traces for 3D points, polygons, and meshes", () => {
+    const visualization = new Plotter(
+      [
+        point([0, 0, 2], "anchor"),
+        lineString(
+          [
+            [0, 0, 1],
+            [1, 1, 2]
+          ],
+          "edge"
+        ),
+        polygon(
+          [
+            [
+              [0, 0, 0],
+              [2, 0, 0],
+              [2, 2, 0],
+              [0, 2, 0],
+              [0, 0, 0]
+            ],
+            [
+              [0.5, 0.5, 0],
+              [1, 0.5, 0],
+              [1, 1, 0],
+              [0.5, 0.5, 0]
+            ]
+          ],
+          "parcel"
+        ),
+        mesh(
+          [
+            [0, 0, 0],
+            [1, 0, 0],
+            [1, 1, 0],
+            [0, 1, 0]
+          ],
+          [
+            [0, 1, 2],
+            [0, 2, 3]
+          ],
+          "slab"
+        )
+      ],
+      { mapZToY: true, orthographic: true, showVertices: false }
+    ).getVisualizationData();
+
+    expect(visualization.kind).toEqual({ plotly: true });
+    expect(visualization.layout).toMatchObject({
+      scene: {
+        aspectmode: "data",
+        camera: { projection: { type: "orthographic" } }
+      }
+    });
+
+    expect(visualization.data).toHaveLength(4);
+    expect(visualization.data[0]).toMatchObject({
+      type: "scatter3d",
+      mode: "markers",
+      name: "anchor",
+      x: [0],
+      y: [2],
+      z: [0]
+    });
+    expect(visualization.data[1]).toMatchObject({
+      type: "scatter3d",
+      mode: "lines",
+      name: "edge",
+      x: [0, 1, null],
+      y: [1, 2, null],
+      z: [0, 1, null]
+    });
+    expect(visualization.data[2]).toMatchObject({
+      type: "scatter3d",
+      mode: "lines",
+      name: "parcel",
+      x: [0, 2, 2, 0, 0, null, 0.5, 1, 1, 0.5, null],
+      y: [0, 0, 0, 0, 0, null, 0, 0, 0, 0, null],
+      z: [0, 0, 2, 2, 0, null, 0.5, 0.5, 1, 0.5, null]
+    });
+    expect(visualization.data[3]).toMatchObject({
+      type: "mesh3d",
+      name: "slab",
+      x: [0, 1, 1, 0],
+      y: [0, 0, 0, 0],
+      z: [0, 0, 1, 1],
+      i: [0, 0],
+      j: [1, 2],
+      k: [2, 3]
+    });
+    expect(JSON.parse(new Plotter([]).visualize(true) as string)).toEqual({
+      kind: { plotly: true },
+      data: [],
+      layout: {
+        scene: {
+          xaxis_title: "X Axis",
+          yaxis_title: "Y Axis",
+          zaxis_title: "Z Axis",
+          aspectmode: "data",
+          camera: { projection: { type: "orthographic" } }
+        }
+      }
+    });
+  });
+
+  it("accepts GeoJSON-like features and feature collections without project-specific adapters", () => {
+    const visualization = new Plotter([
+      {
+        type: "Feature",
+        properties: { name: "survey-points" },
+        geometry: {
+          type: "MultiPoint",
+          coordinates: [
+            [0, 0, 1],
+            [2, 2, 3]
+          ]
+        }
+      },
+      {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: { name: "outline" },
+            geometry: {
+              type: "LineString",
+              coordinates: [
+                [0, 0, 0],
+                [1, 0, 0],
+                [1, 1, 0]
+              ]
+            }
+          }
+        ]
+      }
+    ]).getVisualizationData();
+
+    expect(visualization.data).toHaveLength(2);
+    expect(visualization.data[0]).toMatchObject({
+      type: "scatter3d",
+      mode: "markers",
+      name: "survey-points",
+      x: [0, 2],
+      y: [0, 2],
+      z: [1, 3]
+    });
+    expect(visualization.data[1]).toMatchObject({
+      type: "scatter3d",
+      mode: "lines+markers",
+      name: "outline",
+      x: [0, 1, 1, null],
+      y: [0, 0, 1, null],
+      z: [0, 0, 0, null]
+    });
+  });
+
+  it("accepts mesh-like objects and custom adapters for project-specific objects", () => {
+    const segment = {
+      kind: "Segment",
+      label: "custom-edge",
+      start: { x: 0, y: 0, z: 0 },
+      end: { x: 2, y: 0, z: 1 }
+    };
+
+    const visualization = new Plotter(
+      [
+        {
+          name: "duck-mesh",
+          vertices: [
+            [0, 0, 0],
+            [1, 0, 0],
+            [1, 1, 0]
+          ],
+          faces: [[0, 1, 2]]
+        },
+        segment
+      ],
+      {
+        adapters: [
+          (value) => {
+            if (
+              typeof value === "object" &&
+              value !== null &&
+              "kind" in value &&
+              value.kind === "Segment"
+            ) {
+              return lineString([
+                value.start as { x: number; y: number; z: number },
+                value.end as { x: number; y: number; z: number }
+              ], value.label as string);
+            }
+
+            return undefined;
+          }
+        ]
+      }
+    ).getVisualizationData();
+
+    expect(visualization.data).toHaveLength(2);
+    expect(visualization.data[0]).toMatchObject({
+      type: "mesh3d",
+      name: "duck-mesh",
+      x: [0, 1, 1],
+      y: [0, 0, 1],
+      z: [0, 0, 0],
+      i: [0],
+      j: [1],
+      k: [2]
+    });
+    expect(visualization.data[1]).toMatchObject({
+      type: "scatter3d",
+      mode: "lines+markers",
+      name: "custom-edge",
+      x: [0, 2, null],
+      y: [0, 0, null],
+      z: [0, 1, null]
+    });
+  });
+});

--- a/typescript/tests/plotter.test.ts
+++ b/typescript/tests/plotter.test.ts
@@ -187,10 +187,12 @@ describe("Plotter", () => {
               "kind" in value &&
               value.kind === "Segment"
             ) {
-              return lineString([
-                value.start as { x: number; y: number; z: number },
-                value.end as { x: number; y: number; z: number }
-              ], value.label as string);
+              const seg = value as unknown as {
+                start: { x: number; y: number; z: number };
+                end: { x: number; y: number; z: number };
+                label: string;
+              };
+              return lineString([seg.start, seg.end], seg.label);
             }
 
             return undefined;

--- a/typescript/tests/review-pr3-fixes.test.ts
+++ b/typescript/tests/review-pr3-fixes.test.ts
@@ -144,6 +144,41 @@ describe("review PR #3 fixes", () => {
     ]);
   });
 
+  it(
+    "KR9: MeshLikeGeometry rejects adapter returns lacking (vertices|positions) and (faces|indices)",
+    () => {
+      const pkgDir = process.cwd();
+      const fixturePath = join(pkgDir, "tests", "__kr9-regression.ts");
+      writeFileSync(
+        fixturePath,
+        [
+          'import type { MeshLikeGeometry } from "../src/index";',
+          "// @ts-expect-error: bare { type, name } lacks a (vertices|positions) and (faces|indices) pair",
+          'const overbroad: MeshLikeGeometry = { type: "DomainThing", name: "not-a-generic-geometry" };',
+          "void overbroad;",
+          ""
+        ].join("\n"),
+        "utf8"
+      );
+
+      let typecheckPassed = false;
+      try {
+        execSync("npm run typecheck --silent", {
+          cwd: pkgDir,
+          stdio: ["ignore", "ignore", "ignore"]
+        });
+        typecheckPassed = true;
+      } catch {
+        typecheckPassed = false;
+      } finally {
+        rmSync(fixturePath, { force: true });
+      }
+
+      expect(typecheckPassed).toBe(true);
+    },
+    60_000
+  );
+
   it("KR8: empty TypedArray mesh-like { positions, indices } produces a mesh3d trace at runtime", () => {
     const visualization = new Plotter([
       {

--- a/typescript/tests/review-pr3-fixes.test.ts
+++ b/typescript/tests/review-pr3-fixes.test.ts
@@ -1,0 +1,180 @@
+import { execSync } from "node:child_process";
+import { existsSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  lineString,
+  mesh,
+  point,
+  polygon,
+  Plotter,
+  type GeometryAdapter,
+  type MeshLikeGeometry
+} from "../src/index";
+
+describe("review PR #3 fixes", () => {
+  it("KR1: point() with object-form Coordinate produces a scatter3d trace at runtime", () => {
+    const visualization = new Plotter([
+      point({ x: 1, y: 2, z: 3 }, "object-point")
+    ]).getVisualizationData();
+
+    expect(visualization.data).toHaveLength(1);
+    const trace = visualization.data[0]!;
+    expect(trace.type).toBe("scatter3d");
+    expect(trace.x).toEqual([1]);
+    expect(trace.y).toEqual([2]);
+    expect(trace.z).toEqual([3]);
+  });
+
+  it("KR2: empty mesh-like { vertices: [], faces: [] } produces a mesh3d trace at runtime", () => {
+    const visualization = new Plotter([
+      { vertices: [], faces: [], name: "empty-mesh-like" }
+    ]).getVisualizationData();
+
+    expect(visualization.data).toHaveLength(1);
+    const trace = visualization.data[0]!;
+    expect(trace.type).toBe("mesh3d");
+    expect(trace.x).toEqual([]);
+    expect(trace.y).toEqual([]);
+    expect(trace.z).toEqual([]);
+    expect(trace.i).toEqual([]);
+    expect(trace.j).toEqual([]);
+    expect(trace.k).toEqual([]);
+  });
+
+  it("KR3: GeometryAdapter accepts a function whose return type is MeshLikeGeometry", () => {
+    class Cube {
+      constructor(public readonly size: number) {}
+    }
+
+    const cubeAdapter: GeometryAdapter = (value: unknown): MeshLikeGeometry | undefined => {
+      if (!(value instanceof Cube)) return undefined;
+      const s = value.size;
+      return {
+        vertices: [[0, 0, 0], [s, 0, 0], [s, s, 0], [0, s, 0]],
+        faces: [[0, 1, 2], [0, 2, 3]],
+        name: "cube"
+      };
+    };
+
+    const visualization = new Plotter([new Cube(2)], {
+      adapters: [cubeAdapter]
+    }).getVisualizationData();
+
+    expect(visualization.data).toHaveLength(1);
+    expect(visualization.data[0]!.type).toBe("mesh3d");
+  });
+
+  it(
+    "KR4: npm pack from a clean checkout ships dist/index.js and dist/index.d.ts via prepack",
+    () => {
+      const pkgDir = process.cwd();
+      const distDir = join(pkgDir, "dist");
+      rmSync(distDir, { recursive: true, force: true });
+      expect(existsSync(distDir)).toBe(false);
+
+      const stdout = execSync("npm pack --dry-run --json", {
+        cwd: pkgDir,
+        stdio: ["ignore", "pipe", "ignore"]
+      }).toString("utf8");
+
+      const reports = JSON.parse(stdout) as Array<{
+        files: Array<{ path: string }>;
+      }>;
+      const filePaths = reports[0]!.files.map((entry) => entry.path);
+
+      expect(filePaths).toContain("dist/index.js");
+      expect(filePaths).toContain("dist/index.d.ts");
+    },
+    60_000
+  );
+
+  it(
+    "KR5: published tarball does not ship an orphan dist/index.d.ts.map (or includes the referenced src/)",
+    () => {
+      const pkgDir = process.cwd();
+      const distDir = join(pkgDir, "dist");
+      rmSync(distDir, { recursive: true, force: true });
+
+      const stdout = execSync("npm pack --dry-run --json", {
+        cwd: pkgDir,
+        stdio: ["ignore", "pipe", "ignore"]
+      }).toString("utf8");
+
+      const reports = JSON.parse(stdout) as Array<{
+        files: Array<{ path: string }>;
+      }>;
+      const filePaths = reports[0]!.files.map((entry) => entry.path);
+
+      const hasMap = filePaths.includes("dist/index.d.ts.map");
+      const hasSource = filePaths.includes("src/index.ts");
+      expect(hasMap && !hasSource).toBe(false);
+    },
+    60_000
+  );
+
+  it("KR6: lineString/polygon/mesh accept readonly tuple literals (as const)", () => {
+    const lineCoords = [[0, 0, 0], [1, 0, 0]] as const;
+    const polygonCoords = [
+      [
+        [0, 0, 0],
+        [2, 0, 0],
+        [2, 2, 0],
+        [0, 0, 0]
+      ]
+    ] as const;
+    const vertices = [
+      [0, 0, 0],
+      [1, 0, 0],
+      [1, 1, 0]
+    ] as const;
+    const faces = [[0, 1, 2]] as const;
+
+    const visualization = new Plotter([
+      lineString(lineCoords, "edge"),
+      polygon(polygonCoords, "parcel"),
+      mesh(vertices, faces, "slab")
+    ]).getVisualizationData();
+
+    expect(visualization.data).toHaveLength(3);
+    expect(visualization.data.map((trace) => trace.type)).toEqual([
+      "scatter3d",
+      "scatter3d",
+      "mesh3d"
+    ]);
+  });
+
+  it(
+    "KR7: npm run typecheck fails when a tests/*.ts file has a deliberate type error",
+    () => {
+      const pkgDir = process.cwd();
+      const brokenPath = join(pkgDir, "tests", "__kr7-broken.ts");
+      writeFileSync(
+        brokenPath,
+        [
+          'import { Plotter } from "../src/index";',
+          "const wrong: number = new Plotter([]);",
+          "void wrong;",
+          "export {};",
+          ""
+        ].join("\n"),
+        "utf8"
+      );
+
+      let typecheckFailed = false;
+      try {
+        execSync("npm run typecheck --silent", {
+          cwd: pkgDir,
+          stdio: ["ignore", "ignore", "ignore"]
+        });
+      } catch {
+        typecheckFailed = true;
+      } finally {
+        rmSync(brokenPath, { force: true });
+      }
+
+      expect(typecheckFailed).toBe(true);
+    },
+    60_000
+  );
+});

--- a/typescript/tests/review-pr3-fixes.test.ts
+++ b/typescript/tests/review-pr3-fixes.test.ts
@@ -116,6 +116,21 @@ describe("review PR #3 fixes", () => {
     60_000
   );
 
+  it("KR11: Plotter constructor and adapters option accept readonly arrays (as const)", () => {
+    const passthroughAdapter: GeometryAdapter = (value) =>
+      value instanceof Object && "kind" in (value as object) && (value as { kind: unknown }).kind === "Tag"
+        ? lineString([[0, 0, 0], [1, 0, 0]], (value as { name: string }).name)
+        : undefined;
+
+    const geometries = [{ kind: "Tag", name: "ro" }] as const;
+    const adapters = [passthroughAdapter] as const;
+
+    const visualization = new Plotter(geometries, { adapters }).getVisualizationData();
+
+    expect(visualization.data).toHaveLength(1);
+    expect(visualization.data[0]!.type).toBe("scatter3d");
+  });
+
   it("KR10: exported geometry interfaces accept readonly outer arrays (as const) via direct annotation", () => {
     // Realistic pattern: lift the `as const` literal into a separate binding,
     // then drop it into a value annotated with the exported interface.

--- a/typescript/tests/review-pr3-fixes.test.ts
+++ b/typescript/tests/review-pr3-fixes.test.ts
@@ -9,7 +9,10 @@ import {
   polygon,
   Plotter,
   type GeometryAdapter,
-  type MeshLikeGeometry
+  type LineStringGeometry,
+  type MeshGeometry,
+  type MeshLikeGeometry,
+  type PolygonGeometry
 } from "../src/index";
 
 describe("review PR #3 fixes", () => {
@@ -112,6 +115,48 @@ describe("review PR #3 fixes", () => {
     },
     60_000
   );
+
+  it("KR10: exported geometry interfaces accept readonly outer arrays (as const) via direct annotation", () => {
+    // Realistic pattern: lift the `as const` literal into a separate binding,
+    // then drop it into a value annotated with the exported interface.
+    const lineCoords = [[0, 0, 0], [1, 0, 0]] as const;
+    const polyCoords = [
+      [
+        [0, 0, 0],
+        [2, 0, 0],
+        [2, 2, 0],
+        [0, 0, 0]
+      ]
+    ] as const;
+    const meshVertices = [[0, 0, 0], [1, 0, 0], [1, 1, 0]] as const;
+    const meshFaces = [[0, 1, 2]] as const;
+
+    const line: LineStringGeometry = {
+      type: "LineString",
+      coordinates: lineCoords,
+      name: "ro-line"
+    };
+    const poly: PolygonGeometry = {
+      type: "Polygon",
+      coordinates: polyCoords,
+      name: "ro-poly"
+    };
+    const m: MeshGeometry = {
+      type: "Mesh",
+      vertices: meshVertices,
+      faces: meshFaces,
+      name: "ro-mesh"
+    };
+
+    const visualization = new Plotter([line, poly, m]).getVisualizationData();
+
+    expect(visualization.data).toHaveLength(3);
+    expect(visualization.data.map((trace) => trace.type)).toEqual([
+      "scatter3d",
+      "scatter3d",
+      "mesh3d"
+    ]);
+  });
 
   it("KR6: lineString/polygon/mesh accept readonly tuple literals (as const)", () => {
     const lineCoords = [[0, 0, 0], [1, 0, 0]] as const;

--- a/typescript/tests/review-pr3-fixes.test.ts
+++ b/typescript/tests/review-pr3-fixes.test.ts
@@ -144,6 +144,26 @@ describe("review PR #3 fixes", () => {
     ]);
   });
 
+  it("KR8: empty TypedArray mesh-like { positions, indices } produces a mesh3d trace at runtime", () => {
+    const visualization = new Plotter([
+      {
+        positions: new Float32Array(),
+        indices: new Uint16Array(),
+        name: "empty-typed-array-mesh"
+      }
+    ]).getVisualizationData();
+
+    expect(visualization.data).toHaveLength(1);
+    const trace = visualization.data[0]!;
+    expect(trace.type).toBe("mesh3d");
+    expect(trace.x).toEqual([]);
+    expect(trace.y).toEqual([]);
+    expect(trace.z).toEqual([]);
+    expect(trace.i).toEqual([]);
+    expect(trace.j).toEqual([]);
+    expect(trace.k).toEqual([]);
+  });
+
   it(
     "KR7: npm run typecheck fails when a tests/*.ts file has a deliberate type error",
     () => {

--- a/typescript/tsconfig.json
+++ b/typescript/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "exactOptionalPropertyTypes": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noUncheckedIndexedAccess": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/typescript/tsconfig.json
+++ b/typescript/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "exactOptionalPropertyTypes": true,
     "module": "NodeNext",
     "moduleResolution": "NodeNext",

--- a/typescript/tsconfig.test.json
+++ b/typescript/tsconfig.test.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "rootDir": ".",
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": [
+    "src/**/*.ts",
+    "tests/**/*.ts"
+  ]
+}

--- a/typescript/vitest.config.ts
+++ b/typescript/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"]
+  }
+});


### PR DESCRIPTION
## Summary

Adds an isolated TypeScript package under `typescript/` so the repository can keep the existing Python implementation while adding generic TypeScript helpers for VS Code Debug Visualizer.

## Changes

- Adds a TypeScript `Plotter` that emits Debug Visualizer-compatible Plotly data for points, lines, polygons, multi-geometries, features, feature collections, and triangle meshes.
- Supports generic GeoJSON-like inputs plus mesh-like `{ vertices, faces }` and `{ positions, indices }` objects without baking app-specific class names into the package.
- Adds a custom `adapters` hook so project-specific objects can be mapped into generic geometry outside the package core.
- Adds a headless Node inspector test that pauses at a real `debugger;` statement and evaluates `view.getVisualizationData()` from the current call frame, matching the Debug Visualizer breakpoint-evaluation path.
- Adds npm package metadata, TypeScript strict build config, Vitest tests, and a lockfile scoped to `typescript/`.
- Documents the Python/TypeScript split, breakpoint usage, generic input coverage, and adapter pattern.
- Extends CI to run the existing Python tests and the new TypeScript test/build steps.

## Validation

- `PYTHONPATH=. .venv/bin/pytest tests/`
- `cd typescript && npm test`
- `cd typescript && npm run typecheck`
- `cd typescript && npm run build`
- `cd typescript && npm pack --dry-run`
- `git diff --check`